### PR TITLE
👽️ add responseId to GeminiResponse data class

### DIFF
--- a/plugins/generator_gemini_plugin/src/main/kotlin/de/busesteinkamp/plugins/data/GeminiResponseData.kt
+++ b/plugins/generator_gemini_plugin/src/main/kotlin/de/busesteinkamp/plugins/data/GeminiResponseData.kt
@@ -6,7 +6,8 @@ import kotlinx.serialization.Serializable
 data class GeminiResponse(
     val candidates: List<Candidate>,
     val usageMetadata: UsageMetadata,
-    val modelVersion: String
+    val modelVersion: String,
+    val responseId: String,
 )
 
 @Serializable


### PR DESCRIPTION
This pull request introduces a small change to the `GeminiResponse` data class in the `GeminiResponseData.kt` file. The change adds a new property, `responseId`, to the class to include additional information in the response model.

* [`plugins/generator_gemini_plugin/src/main/kotlin/de/busesteinkamp/plugins/data/GeminiResponseData.kt`](diffhunk://#diff-7c129c3faca64902687390ac18423338f4e0b70cc69d6a11bbdf7f053042c103L9-R10): Added a `responseId` property to the `GeminiResponse` data class.